### PR TITLE
Remove the back/next buttons instead of disabling them

### DIFF
--- a/src/lib/ViewSet.svelte
+++ b/src/lib/ViewSet.svelte
@@ -244,17 +244,19 @@
 			displayFrom = displayFrom;
 		}}
 		class="page back"
-		aria-label="Previous page"><div /></button
-	>{:else}<button disabled class="page back" aria-label="Previous page" />
+		aria-label="Previous page"
+	>
+		<div />
+	</button>
 {/if}
 {#if !visible[visible.length - 1]}
 	<button
 		on:click={() => (displayFrom = [...displayFrom, visible.indexOf(false)])}
 		class="page next"
-		aria-label="Next page"><div /></button
+		aria-label="Next page"
 	>
-{:else}
-	<button class="page next" disabled aria-label="Next page" />
+		<div />
+	</button>
 {/if}
 
 <style lang="postcss">


### PR DESCRIPTION
Fixes #29

I believe this was added before `touch-action` was added to the CSS. Without `touch-action` set, repeatedly pressing back could cause the browser to zoom if there wasn't a button to hit. Now the page naturally ignores double taps, there is no value in disabling the button, and it instead just disappears entirely.