### PR TITLE
Add a hide/show notes button

### DIFF
--- a/src/lib/ViewSet.svelte
+++ b/src/lib/ViewSet.svelte
@@ -35,6 +35,7 @@
 
 	$: slotFilled = $$slots.default;
 	$: notesBeside = keyedLocalStorage(`${set.slug}_${orientation}_notesBeside`, false);
+	$: notesHidden = keyedLocalStorage(`${set.slug}_${orientation}_notesHidden`, false);
 
 	type ExtraTuneProps = { div?: Element; originalKey?: KeySignature; offset: Writable<number> };
 
@@ -184,6 +185,12 @@
 						$refreshVisibility++;
 					}}>Notes {$notesBeside ? 'below' : 'beside'}</button
 				>
+				<button
+					on:click={() => {
+						$notesHidden = !$notesHidden;
+						$refreshVisibility++;
+					}}>{$notesHidden ? 'Show' : 'Hide'} notes</button
+				>
 			{/if}
 			<p>Current zoom level {$maxWidth}%</p>
 		</div>
@@ -230,7 +237,9 @@
 		{/each}
 	</div>
 
-	<div class="notes-container"><slot /></div>
+	{#if !$notesHidden}
+		<div class="notes-container"><slot /></div>
+	{/if}
 </div>
 
 {#if displayFrom.length > 1}


### PR DESCRIPTION
Kinda naive but probably good enough for a first version? 

Doesn't work well if you have notes beside, it keeps the space in the grid reserved but doesn't put anything in it - is there a better way to handle that?

Also I have no memory of how to make a release of an updated version

Closes #43 