### PR TITLE
v0.6

### DIFF
--- a/src/lib/FilterSets.svelte
+++ b/src/lib/FilterSets.svelte
@@ -3,7 +3,9 @@
 	import { keyedLocalStorage } from './keyedLocalStorage';
 
 	interface Props {
+		/** The folder to display sets from */
 		folder: Folder;
+		/** The title to display above the filter checkboxes */
 		filtersTitle?: string;
 		children?: import('svelte').Snippet<[any]>;
 	}

--- a/src/lib/FilterableSetsGrid.svelte
+++ b/src/lib/FilterableSetsGrid.svelte
@@ -4,11 +4,21 @@
 	import type { Folder } from './types/index.js';
 
 	interface Props {
+		/** The folder to display sets from */
 		folder: Folder;
+		/** The font family to use for text rendered as part of the ABC */
 		tuneFont?: string | undefined;
+		/** The title to display above the filter checkboxes */
 		filtersTitle?: string | undefined;
+		/** A list of ABC headers to display, specified as a string (e.g. 'TCBN') */
 		displayAbcFields?: string | undefined;
+		/** Should the set-level text notes be displayed? */
 		showNotes?: boolean | undefined;
+		/**
+		 * The base path for the links to sets Set this if you have a base path
+		 * for the site e.g. 'tunes/' if the tunebook is hosted at
+		 * 'https://example.com/tunes/'
+		 */
 		basePath?: string | undefined;
 	}
 

--- a/src/lib/GlobalTranspositionButtons.svelte
+++ b/src/lib/GlobalTranspositionButtons.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { keyedLocalStorage } from './keyedLocalStorage';
+
+	export let globalTransposition = keyedLocalStorage('globalTransposition', 0);
+</script>
+
+<p class="mx-auto w-fit flex flex-wrap gap-2">
+	<button onclick={() => ($globalTransposition = 2)}>Make the folder B♭</button>
+	<button onclick={() => ($globalTransposition = 0)}>Make the folder C</button>
+	<button onclick={() => ($globalTransposition = -3)}>Make the folder E♭</button>
+</p>

--- a/src/lib/GlobalTranspositionButtons.svelte
+++ b/src/lib/GlobalTranspositionButtons.svelte
@@ -1,11 +1,30 @@
 <script lang="ts">
+	import type { Writable } from 'svelte/store';
 	import { keyedLocalStorage } from './keyedLocalStorage';
+	import type { Clef } from './types';
 
-	export let globalTransposition = keyedLocalStorage('globalTransposition', 0);
+	interface Props {
+		/** Should the clef switcher be shown? */
+		showClefSwitcher?: boolean;
+	}
+
+	let { showClefSwitcher = false }: Props = $props();
+
+	let globalTransposition = keyedLocalStorage('globalTransposition', 0);
+	let globalClef: Writable<Clef> = keyedLocalStorage('globalClef', 'treble');
+
+	function toggleClef() {
+		globalClef.update((c) => (c === 'treble' ? 'bass' : 'treble'));
+	}
 </script>
 
 <p class="mx-auto w-fit flex flex-wrap gap-2">
 	<button onclick={() => ($globalTransposition = 2)}>Make the folder B♭</button>
 	<button onclick={() => ($globalTransposition = 0)}>Make the folder C</button>
 	<button onclick={() => ($globalTransposition = -3)}>Make the folder E♭</button>
+	{#if showClefSwitcher}
+		<button onclick={toggleClef}>
+			{$globalClef === 'treble' ? 'Switch to bass clef' : 'Switch to treble clef'}
+		</button>
+	{/if}
 </p>

--- a/src/lib/Incipit.svelte
+++ b/src/lib/Incipit.svelte
@@ -4,8 +4,11 @@
 	import { keyedLocalStorage } from './keyedLocalStorage';
 
 	interface Props {
+		/** The full ABC for the tune you want to display */
 		abc: string;
+		/** The font family to use for text rendered as part of the ABC */
 		fontFamily?: string | undefined;
+		/** A list of ABC headers to display, specified as a string (e.g. 'TCBN') */
 		displayAbcFields?: string;
 	}
 
@@ -17,7 +20,7 @@
 
 	let preservedFieldRegex = $derived(new RegExp(`^[XKML${displayAbcFields}]`));
 
-	const visualTranspose = keyedLocalStorage('globalTransposition', 0);
+	const globalTransposition = keyedLocalStorage('globalTransposition', 0);
 
 	function firstTwoBars(abcTuneSection: string): string {
 		const [firstChar, rest] = [abcTuneSection[0], abcTuneSection.slice(1)];
@@ -44,5 +47,5 @@
 	titleSize={12}
 	tuneOffset={writable(0)}
 	showTransposition={false}
-	visualTranspose={$visualTranspose}
+	globalTransposition={$globalTransposition}
 />

--- a/src/lib/KeySelect.svelte
+++ b/src/lib/KeySelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { KeyAccidentalName, KeyRoot, KeySignature } from 'abcjs';
 	import type { Readable } from 'svelte/store';
+	import { keyedLocalStorage } from './keyedLocalStorage';
 
 	interface Props {
 		originalKey: KeySignature;
@@ -9,6 +10,7 @@
 	}
 
 	let { originalKey, transposition, tuneSlug }: Props = $props();
+	let globalTransposition = keyedLocalStorage(`globalTransposition`, 0);
 
 	const ROOTS = ['A', 'B♭', 'B', 'C', 'D♭', 'D', 'E♭', 'E', 'F', 'F♯', 'G', 'A♭'];
 
@@ -48,7 +50,15 @@
 		} else if (transposition < 0) {
 			return `(${transposition})`;
 		} else {
-			return `(concert)`;
+			if ($globalTransposition === 0) {
+				return `(concert)`;
+			} else if ($globalTransposition === 2) {
+				return `("concert" - folder in B♭)`;
+			} else if ($globalTransposition === -3) {
+				return `("concert" - folder in E♭)`;
+			} else {
+				return `(globally transposed)`;
+			}
 		}
 	}
 
@@ -56,7 +66,8 @@
 	let availableKeys = $derived(
 		[...Array(24).keys()].map((i) => {
 			const transposition = i - 11;
-			const root = ROOTS[(ROOT_NUMBERS[writtenKey] + 12 + transposition) % 12];
+			const root =
+				ROOTS[(ROOT_NUMBERS[writtenKey] + 12 + transposition + $globalTransposition) % 12];
 			let mode: string = originalKey.mode;
 			if (!mode.match(/m?/)) {
 				mode = ` ${mode}`;

--- a/src/lib/Tune.svelte
+++ b/src/lib/Tune.svelte
@@ -78,8 +78,19 @@
 	// Normalize repeats to start at the beginning of a line rather than the end of the previous line
 	// abcjs displays repeats where written in the abc, so it looks weird if we don't do this
 	let amendedAbc = $derived(abc.replace(/\|: *\n/g, '||\n|:').replace(/::.*\n/g, ':|\n|:'));
-	// TODO might be nice to say what these mean eg +2 = for B♭ instruments
-	let transpose_summary = $derived(`Transposed ${$tuneOffset > 0 ? '+' : ''}${$tuneOffset}`);
+	let tuneOffsetMagnitude = $derived((($tuneOffset % 12) + 12) % 12);
+	let transposeName = $derived(
+		globalTransposition === 0
+			? tuneOffsetMagnitude === 2
+				? '(for B♭ instruments)'
+				: tuneOffsetMagnitude === 9
+					? '(for E♭ instruments)'
+					: ''
+			: ''
+	);
+	let transpose_summary = $derived(
+		`Transposed ${$tuneOffset > 0 ? '+' : ''}${$tuneOffset} ${transposeName}`.trim()
+	);
 	let moreAmendedAbc = $derived(
 		showTransposition && $tuneOffset !== 0
 			? amendedAbc.replace(

--- a/src/lib/Tune.svelte
+++ b/src/lib/Tune.svelte
@@ -6,9 +6,16 @@
 	import { tick, untrack } from 'svelte';
 	let dots: HTMLDivElement | undefined = $state();
 	interface Props {
-		visualTranspose?: number;
+		/** The number of semitones to transpose all tunes by
+		 *
+		 * For example, to make a Bb folder, set this to 2
+		 */
+		globalTransposition?: number;
+		/** The number of semitones to transpose the tune by */
 		tuneOffset: Writable<number>;
+		/** The ABC for the tune you want to display */
 		abc: string;
+		/** The font family to use for text rendered as part of the ABC */
 		fontFamily?: string | undefined;
 		staffwidth?: number | undefined;
 		tunesContainer?: Element | undefined;
@@ -21,7 +28,7 @@
 	}
 
 	let {
-		visualTranspose = 0,
+		globalTransposition = 0,
 		tuneOffset,
 		abc,
 		fontFamily = undefined,
@@ -100,7 +107,7 @@
 							wordsfont: `${fontFamily} ${fontSize}`
 						}
 					: {},
-				visualTranspose: visualTranspose + $tuneOffset,
+				visualTranspose: globalTransposition + $tuneOffset,
 				selectTypes: false,
 				responsive: 'resize',
 				// This makes typescript happy that staffwidth is not undefined

--- a/src/lib/Tune.svelte
+++ b/src/lib/Tune.svelte
@@ -9,9 +9,10 @@
 		/** The number of semitones to transpose all tunes by
 		 *
 		 * For example, to make a Bb folder, set this to 2
+		 * and to make a Eb folder, set this to -3
 		 */
 		globalTransposition?: number;
-		/** The number of semitones to transpose the tune by */
+		/** The number of semitones to transpose this tune by */
 		tuneOffset: Writable<number>;
 		/** The ABC for the tune you want to display */
 		abc: string;

--- a/src/lib/ViewSet.svelte
+++ b/src/lib/ViewSet.svelte
@@ -32,7 +32,22 @@
 		throw Error(`displayAbcFields should be a string of (uppercase) ABC field names`);
 	}
 
-	let preservedFieldRegex = $derived(new RegExp(`^[XKML${displayAbcFields}]`));
+	let innerHeight: number = $state(0),
+		innerWidth: number = $state(0);
+	let orientation = $derived(innerHeight >= innerWidth ? 'portrait' : 'landscape');
+	let slotFilled = $derived(children !== undefined);
+	let notesBeside = $derived(keyedLocalStorage(`${set.slug}_${orientation}_notesBeside`, false));
+	let notesHidden = $derived(keyedLocalStorage(`${set.slug}_${orientation}_notesHidden`, false));
+	let globalClef: Writable<Clef> = keyedLocalStorage('globalClef', 'treble');
+	let clef: Writable<Clef | 'global'> = $derived(keyedLocalStorage(`${set.slug}_clef`, 'global'));
+	let preservedFieldRegex = $derived(
+		new RegExp(
+			`^[XKML${displayAbcFields
+				.split('')
+				.filter((f) => !$notesHidden || !'BNSF'.includes(f))
+				.join('')}]`
+		)
+	);
 
 	function stripUnwantedHeaders(abc: string): string {
 		const trimmedAbc = abc.replace(/\n\s*/g, '\n').replace(/%[^\n]*\n/g, '');
@@ -57,15 +72,6 @@
 	}
 
 	const ROOTS = ['A', 'B♭', 'B', 'C', 'D♭', 'D', 'E♭', 'E', 'F', 'F♯', 'G', 'A♭'];
-
-	let innerHeight: number = $state(0),
-		innerWidth: number = $state(0);
-	let orientation = $derived(innerHeight >= innerWidth ? 'portrait' : 'landscape');
-	let slotFilled = $derived(children !== undefined);
-	let notesBeside = $derived(keyedLocalStorage(`${set.slug}_${orientation}_notesBeside`, false));
-	let notesHidden = $derived(keyedLocalStorage(`${set.slug}_${orientation}_notesHidden`, false));
-	let globalClef: Writable<Clef> = keyedLocalStorage('globalClef', 'treble');
-	let clef: Writable<Clef | 'global'> = $derived(keyedLocalStorage(`${set.slug}_clef`, 'global'));
 
 	type ExtraTuneProps = { div?: Element; originalKey?: KeySignature; offset: Writable<number> };
 

--- a/src/lib/ViewSet.svelte
+++ b/src/lib/ViewSet.svelte
@@ -71,7 +71,7 @@
 	});
 
 	let tunesContainer: Element | undefined = $state();
-	let visualTranspose = keyedLocalStorage(`globalTransposition`, 0);
+	let globalTransposition = keyedLocalStorage(`globalTransposition`, 0);
 	let hideControls = $state(true);
 	let autozoomEnabled = $derived(keyedLocalStorage(`${set.slug}_${orientation}_autozoom`, true));
 
@@ -175,7 +175,7 @@
 <div class="page-container" class:notes-beside={$notesBeside && slotFilled && !$notesHidden}>
 	<div class="controls-container">
 		<span class="key-reminder"
-			>Folder key: {ROOTS[(ROOTS.length + 3 - $visualTranspose) % ROOTS.length]}</span
+			>Folder key: {ROOTS[(ROOTS.length + 3 - $globalTransposition) % ROOTS.length]}</span
 		>
 		<button class="toggle-controls" onclick={() => (hideControls = !hideControls)}
 			>{hideControls ? 'Show' : 'Hide'} controls</button
@@ -249,7 +249,7 @@
 					>
 					<Tune
 						abc={stripUnwantedHeaders(tune.abc)}
-						visualTranspose={$visualTranspose}
+						globalTransposition={$globalTransposition}
 						tuneOffset={tune.offset}
 						bind:visible={visible[i]}
 						{refreshVisibility}

--- a/src/lib/ViewSet.svelte
+++ b/src/lib/ViewSet.svelte
@@ -11,10 +11,10 @@
 	const { renderAbc } = pkg;
 
 	interface Props {
-		folderName: string;
+		folderName?: string;
 		set: Set;
 		fontFamily?: string;
-		displayAbcFields: string;
+		displayAbcFields?: string;
 		children: Snippet;
 	}
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,4 +3,5 @@ export { default as Incipit } from './Incipit.svelte';
 export { default as FilterableSetsGrid } from './FilterableSetsGrid.svelte';
 export { default as FilterSets } from './FilterSets.svelte';
 export { default as SetPreview } from './SetPreview.svelte';
+export { default as GlobalTranspositionButtons } from './GlobalTranspositionButtons.svelte';
 export { keyedLocalStorage } from './keyedLocalStorage.js';

--- a/src/lib/server/folderGeneration.ts
+++ b/src/lib/server/folderGeneration.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 import slugify from 'slugify';
-import type { Folder, Section, Set } from '$lib/types/index.js';
+import type { AddSetProps, Folder, Section, Set } from '$lib/types/index.js';
 
 export async function generateFolderFromLatex(
 	folderName: string,
@@ -59,6 +59,26 @@ export async function generateFolderFromLatex(
 	return folder;
 }
 
+export function addNextPreviousSlugs(
+	folder: Folder
+): AddSetProps<{ nextSlug: string; previousSlug: string }> {
+	const allSets = folder.content.flatMap((section) => section.content);
+	return {
+		...folder,
+		content: folder.content.map((section) => ({
+			name: section.name,
+			content: section.content.map((set) => {
+				const index = allSets.findIndex((s) => s.slug == set.slug);
+				return {
+					...set,
+					nextSlug: allSets.at((index + 1) % allSets.length)!.slug,
+					previousSlug: allSets.at(index - 1)!.slug
+				};
+			})
+		}))
+	};
+}
+
 function addTagsFrom(abc: string, tags: string[]) {
 	for (const tag of extractTags(abc)) {
 		if (!tags.includes(tag)) {
@@ -89,10 +109,7 @@ export async function generateFolderFromMultiSetAbcFile(
 	return generateFolderFromMultiSetAbcString(folderName, abc);
 }
 
-async function generateFolderFromMultiSetAbcString(
-	folderName: string,
-	abc: string
-): Promise<Folder> {
+function generateFolderFromMultiSetAbcString(folderName: string, abc: string): Folder {
 	const folder: Folder = {
 		name: folderName,
 		content: []
@@ -266,44 +283,87 @@ if (import.meta.vitest) {
 	describe('generateFolderFromMultiSetAbcString', () => {
 		const sut = generateFolderFromMultiSetAbcString;
 
-		it('extracts tags from set-level headers', async () => {
+		it('extracts tags from set-level headers', () => {
 			const abc = `X:1\nT:Jigs 1 - Som jigs\nG:Show set\nP:A\nT:A tune\n% ...\nabcdef\nX:2`;
 
-			const folder = await sut('Test folder', abc);
+			const folder = sut('Test folder', abc);
 
 			expect(folder.content[0].content[0].tags).toEqual(['Show set']);
 		});
 
-		it('applies global key to first tune', async () => {
+		it('applies global key to first tune', () => {
 			const abc = `X:1\nT:Jigs 1 - Som jigs\nK:G\nP:A\nT:A tune\n% ...\nabcdef\nX:2`;
 
-			const folder = await sut('Test folder', abc);
+			const folder = sut('Test folder', abc);
 
 			expect(folder.content[0].content[0].content[0].abc).toContain('K:G');
 		});
 
-		it('applies tune-specific key to first tune', async () => {
+		it('applies tune-specific key to first tune', () => {
 			const abc = `X:1\nT:Jigs 1 - Som jigs\nP:A\nT:A tune\nK:G\n% ...\nabcdef\nX:2`;
 
-			const folder = await sut('Test folder', abc);
+			const folder = sut('Test folder', abc);
 
 			expect(folder.content[0].content[0].content[0].abc).toContain('K:G');
 		});
 
-		it('does not override tune specific key with global key', async () => {
+		it('does not override tune specific key with global key', () => {
 			const abc = `X:1\nT:Jigs 1 - Som jigs\nK:G\nP:A\nT:A tune\nK:A\n% ...\nabcdef\nX:2`;
 
-			const folder = await sut('Test folder', abc);
+			const folder = sut('Test folder', abc);
 
 			expect(folder.content[0].content[0].content[0].abc).not.toContain('K:G');
 		});
 
-		it('extracts tags from tune-level headers', async () => {
+		it('extracts tags from tune-level headers', () => {
 			const abc = `X:1\nT:Jigs 1 - Som jigs\nP:A\nT:A tune\nG:English\n% ...\nabcdef\nX:2`;
 
-			const folder = await sut('Test folder', abc);
+			const folder = sut('Test folder', abc);
 
 			expect(folder.content[0].content[0].tags).toEqual(['English']);
+		});
+	});
+
+	describe('addNextPreviousSlugs', () => {
+		const sut = addNextPreviousSlugs;
+
+		it('adds next and previous slugs to sets', () => {
+			const abc = `X:1\nT:Jigs 1 - Som jigs\nG:Show set\nP:A\nT:A tune\n% ...\nabcdef\nX:2\nT: Jigs 2 - test\nP:A\nT:Another tune\n% ...\nabcdef\nX:3\nT: Jigs 3 - mor choon\nP:A\nT:Yet another tune\n% ...\nabcdef`;
+			const folder = generateFolderFromMultiSetAbcString('Test folder', abc);
+
+			const result = sut(folder);
+
+			expect(result.content[0].content[1].nextSlug).toEqual('Jigs-3-mor-choon');
+			expect(result.content[0].content[1].previousSlug).toEqual('Jigs-1-Som-jigs');
+		});
+
+		it('previous set for first tune wraps to end', () => {
+			const abc = `X:1\nT:Jigs 1 - Som jigs\nG:Show set\nP:A\nT:A tune\n% ...\nabcdef\nX:2\nT: Jigs 2 - test\nP:A\nT:Another tune\n% ...\nabcdef\nX:3\nT: Jigs 3 - mor choon\nP:A\nT:Yet another tune\n% ...\nabcdef`;
+			const folder = generateFolderFromMultiSetAbcString('Test folder', abc);
+
+			const result = sut(folder);
+
+			expect(result.content[0].content[0].previousSlug).toEqual('Jigs-3-mor-choon');
+		});
+
+		it('next set for last tune wraps to start', () => {
+			const abc = `X:1\nT:Jigs 1 - Som jigs\nG:Show set\nP:A\nT:A tune\n% ...\nabcdef\nX:2\nT: Jigs 2 - test\nP:A\nT:Another tune\n% ...\nabcdef\nX:3\nT: Jigs 3 - mor choon\nP:A\nT:Yet another tune\n% ...\nabcdef`;
+			const folder = generateFolderFromMultiSetAbcString('Test folder', abc);
+
+			const result = sut(folder);
+
+			expect(result.content[0].content[2].nextSlug).toEqual('Jigs-1-Som-jigs');
+		});
+
+		it('crosses section boundaries', () => {
+			const abc = `X:1\nT:Jigs 1 - Som jigs\nG:Show set\nP:A\nT:A tune\n% ...\nabcdef\nX:2\nT: Jigs 2 - test\nP:A\nT:Another tune\n% ...\nabcdef\nX:3\nT: Reels 3 - mor choon\nP:A\nT:Yet another tune\n% ...\nabcdef`;
+			const folder = generateFolderFromMultiSetAbcString('Test folder', abc);
+
+			const result = sut(folder);
+
+			expect(result.content[1].content[0].nextSlug).toEqual('Jigs-1-Som-jigs');
+			expect(result.content[1].content[0].previousSlug).toEqual('Jigs-2-test');
+			expect(result.content[0].content[1].nextSlug).toEqual('Reels-3-mor-choon');
 		});
 	});
 }

--- a/src/lib/server/folderGeneration.ts
+++ b/src/lib/server/folderGeneration.ts
@@ -67,7 +67,8 @@ function addTagsFrom(abc: string, tags: string[]) {
 	}
 }
 
-function extractTags(abc: string): string[] {
+/** Extract the tags from the `G` fields in the abc string */
+export function extractTags(abc: string): string[] {
 	const results = [];
 	for (const match of abc.matchAll(/^G: *([\w, -]+) *$/gm)) {
 		results.push(

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -23,3 +23,4 @@ export type Tune = {
 };
 
 export type AddSetProps<Props> = Folder & { content: { content: Props[] }[] };
+export type Clef = 'treble' | 'bass';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -21,3 +21,5 @@ export type Tune = {
 	slug: string;
 	abc: string;
 };
+
+export type AddSetProps<Props> = Folder & { content: { content: Props[] }[] };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,7 @@
 </p>
 
 <h2>Global transposition options</h2>
-<GlobalTranspositionButtons />
+<GlobalTranspositionButtons showClefSwitcher />
 
 <div class="filterable-sets-grid">
 	<FilterableSetsGrid folder={data.folder} tuneFont="sans-serif" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import FilterableSetsGrid from '$lib/FilterableSetsGrid.svelte';
-	import { keyedLocalStorage } from '$lib/keyedLocalStorage.js';
+	import GlobalTranspositionButtons from '$lib/GlobalTranspositionButtons.svelte';
 
 	let { data } = $props();
-
-	const visualTranspose = keyedLocalStorage('globalTransposition', 0);
 </script>
 
 <svelte:head>
@@ -20,11 +18,7 @@
 </p>
 
 <h2>Global transposition options</h2>
-<p class="mx-auto w-fit flex flex-wrap gap-2">
-	<button onclick={() => ($visualTranspose = 2)}>Make the folder B♭</button>
-	<button onclick={() => ($visualTranspose = 0)}>Make the folder C</button>
-	<button onclick={() => ($visualTranspose = -3)}>Make the folder E♭</button>
-</p>
+<GlobalTranspositionButtons />
 
 <div class="filterable-sets-grid">
 	<FilterableSetsGrid folder={data.folder} tuneFont="sans-serif" />

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -5,7 +5,13 @@
 </script>
 
 <button class="z-20 fixed left-3 top-3" onclick={() => history.back()}>Back</button>
-<ViewSet {set} folderName={data.folder.name} fontFamily="sans-serif" displayAbcFields="TNCRO">
+<ViewSet
+	{set}
+	folderName={data.folder.name}
+	fontFamily="sans-serif"
+	displayAbcFields="TNCRO"
+	showClefSwitcher
+>
 	<h2>Extra notes</h2>
 	{#if set.notes}
 		<p style="font-style:italic">{set.notes}</p>

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -132,6 +132,24 @@ test('manually zoomed tunes reflow to fit page when controls are hidden', async 
 	await expect(thirdTune).toBeInViewport();
 });
 
+test('set and tune notes can be hidden', async ({ page }) => {
+	await page.goto('/Jigs-2-Lots-of-jigs');
+	await expect(page.getByText('Extra notes', { exact: true })).toBeVisible();
+	await expect(
+		page.getByText('Extra notes for a set can be placed directly inside <ViewSet>')
+	).toBeVisible();
+	await expect(page.getByText(`Here's a note in a tune's ABC N: field`)).toBeVisible();
+
+	await page.getByRole('button', { name: 'Show controls' }).click();
+	await page.getByRole('button', { name: 'Hide notes' }).click();
+
+	await expect(page.getByText('Extra notes', { exact: true })).not.toBeVisible();
+	await expect(
+		page.getByText('Extra notes for a set can be placed directly inside <ViewSet>')
+	).not.toBeVisible();
+	await expect(page.getByText(`Here's a note in a tune's ABC N: field`)).not.toBeVisible();
+});
+
 test('first page remains unchanged upon return', async ({ page }) => {
 	const secondTune = page.getByText('The Silver Spear', { exact: true });
 	const thirdTune = page.getByText("Paddy's Trip To Scotland", { exact: true });

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -98,15 +98,44 @@ test('autozoom zooms tunes sensibly after the second tune is transposed', async 
 	await page.getByRole('button', { name: 'Show controls' }).tap();
 	await expect(page.getByText('Upton upon Severn Stick Dance', { exact: true })).toBeInViewport();
 
-	const transpositionSubtitle = page.getByText('Transposed +2', { exact: true });
+	const transpositionSubtitle = page.getByText('Transposed +3', { exact: true });
 	await expect(transpositionSubtitle).not.toBeInViewport();
-	await page.getByLabel('Transpose abc-seven-stars').selectOption('E (+2)');
+	await page.getByLabel('Transpose abc-seven-stars').selectOption('F (+3)');
 	await expect(page.getByText('Seven Stars', { exact: true })).toBeInViewport();
 	await expect(transpositionSubtitle).toBeInViewport();
 
 	await page.getByRole('button', { name: 'Hide controls' }).tap();
 	await expect(page.getByText('Upton upon Severn Stick Dance', { exact: true })).toBeVisible();
 	await expect(page.getByText('Seven Stars', { exact: true })).toBeInViewport();
+});
+
+test('transposition summary recognises Bb/Eb', async ({ page }) => {
+	await page.goto('/Jigs-1-Severn-Stars');
+	await expect(page.getByText('Upton upon Severn Stick Dance', { exact: true })).toBeInViewport();
+	await expect(page.getByText('Seven Stars', { exact: true })).toBeInViewport();
+	await page.getByRole('button', { name: 'Show controls' }).tap();
+
+	let transpositionSubtitle = page.getByText('Transposed +2 (for B♭ instruments)', { exact: true });
+	await expect(transpositionSubtitle).not.toBeInViewport();
+	await page.getByLabel('Transpose abc-seven-stars').selectOption('E (+2)');
+	await expect(transpositionSubtitle).toBeVisible();
+
+	transpositionSubtitle = page.getByText('Transposed -10 (for B♭ instruments)', { exact: true });
+	await page.getByLabel('Transpose abc-seven-stars').selectOption('E (-10)');
+	await expect(transpositionSubtitle).toBeVisible();
+
+	transpositionSubtitle = page.getByText('Transposed -3 (for E♭ instruments)', { exact: true });
+	await page.getByLabel('Transpose abc-seven-stars').selectOption('B (-3)');
+	await expect(transpositionSubtitle).toBeVisible();
+
+	await page.goto('/');
+	await page.getByText('Make the folder B♭').click();
+
+	await page.goto('/Jigs-1-Severn-Stars');
+	await expect(page.getByText('Upton upon Severn Stick Dance', { exact: true })).toBeInViewport();
+	await expect(page.getByText('Seven Stars', { exact: true })).toBeInViewport();
+	await expect(page.getByText('Transposed -3')).toBeVisible();
+	await expect(page.getByText('(for E♭ instruments)')).not.toBeVisible();
 });
 
 test('manually zoomed tunes reflow to fit page when controls are hidden', async ({ page }) => {


### PR DESCRIPTION
- Add docs for all exported components (fixes #23)
- Create a component for global transposition buttons
- Export `extractTags` for easy reuse in custom abc source parsing logic
- Create `addNextPreviousSlugs` button to enable people to create "next set"/"previous set" links (fixes #54)
- Correct type definitions in `ViewSet` to make sure that people don't have to provide defaults unnecessarily (fixes #53)
- Add optional clef switcher (fixes #57)
- Hide ABC as well as set notes (fixes #48)
- Improve key labelling when tunes are globally transposed (fixes #40)
- Highlight Bb/Eb transpositions when not globally transposed  (e.g. "Transposed -3 (for E♭ instruments)")