### PR TITLE
Add keyboard-based page turning to support bluetooth page turners

### DIFF
--- a/src/lib/ViewSet.svelte
+++ b/src/lib/ViewSet.svelte
@@ -221,6 +221,31 @@
 		autoZooming = false;
 		$maxWidth = $maxWidth;
 	}
+
+	function nextPage() {
+		if (!visible[visible.length - 1]) {
+			displayFrom = [...displayFrom, visible.indexOf(false)];
+		}
+	}
+
+	function previousPage() {
+		if (displayFrom.length > 1) {
+			window.scrollBy(0, -25);
+			displayFrom.pop();
+		}
+	}
+
+	function onkeydown(event: KeyboardEvent) {
+		if (event.target instanceof HTMLSelectElement) {
+			return;
+		} else if (['ArrowRight', 'PageDown', 'ArrowDown'].includes(event.key)) {
+			nextPage();
+		} else if (['ArrowLeft', 'PageUp', 'ArrowUp'].includes(event.key)) {
+			previousPage();
+		} else if (event.key === 'Escape') {
+			hideControls = true;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -230,7 +255,7 @@
 {#if !preventWakelock}
 	<drab-wakelock locked auto-lock></drab-wakelock>
 {/if}
-<svelte:window bind:innerHeight bind:innerWidth />
+<svelte:window bind:innerHeight bind:innerWidth {onkeydown} />
 
 <div class="page-container" class:notes-beside={$notesBeside && slotFilled && !$notesHidden}>
 	<div class="controls-container">
@@ -354,23 +379,12 @@
 </div>
 
 {#if displayFrom.length > 1}
-	<button
-		onclick={() => {
-			window.scrollBy(0, -25);
-			displayFrom.pop();
-		}}
-		class="page back"
-		aria-label="Previous page"
-	>
+	<button onclick={previousPage} class="page back" aria-label="Previous page">
 		<div></div>
 	</button>
 {/if}
 {#if !visible[visible.length - 1]}
-	<button
-		onclick={() => (displayFrom = [...displayFrom, visible.indexOf(false)])}
-		class="page next"
-		aria-label="Next page"
-	>
+	<button onclick={nextPage} class="page next" aria-label="Next page">
 		<div></div>
 	</button>
 {/if}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -171,6 +171,25 @@ test('set navigates to start when switching between different sets', async ({ pa
 	await expect(page.getByText('The Cliffs Of Moher', { exact: true })).not.toBeInViewport();
 	await expect(page.getByText('Spirit of the Dance', { exact: true })).toBeInViewport();
 
+	// Verify that we can navigate back and forth between the two tunes with the arrow keys
+	await page.keyboard.press('ArrowLeft');
+	await expect(page.getByText('The Cliffs Of Moher', { exact: true })).toBeInViewport();
+	await expect(page.getByText('Spirit of the Dance', { exact: true })).not.toBeInViewport();
+
+	await page.keyboard.press('ArrowRight');
+	await expect(page.getByText('The Cliffs Of Moher', { exact: true })).not.toBeInViewport();
+	await expect(page.getByText('Spirit of the Dance', { exact: true })).toBeInViewport();
+
+	// Check that pressing the right arrow key many times causes us to stay at the end of the set
+	await page.keyboard.press('ArrowRight');
+	await page.keyboard.press('ArrowRight');
+	await page.keyboard.press('ArrowRight');
+	await page.keyboard.press('ArrowRight');
+	await expect(page.getByText('The Kesh', { exact: true })).toBeInViewport();
+
+	await page.keyboard.press('ArrowLeft');
+	await expect(page.getByText('The Kesh', { exact: true })).not.toBeInViewport();
+
 	// Navigate back to the previous set, check that we're sent to the start of said set
 	await page.getByRole('link', { name: 'Previous set' }).click();
 	await expect(page.getByText('Upton upon Severn Stick Dance', { exact: true })).toBeInViewport();


### PR DESCRIPTION
Currently this supports the following actions:
- ArrowRight/PageDown/ArrowDown: next page
- ArrowLeft/PageUp/ArrowUp: previous page
- Escape: hide the controls (if shown) (suggested by copilot and I thought it was neat, if probably useless in practice) 

This should mean we support page turners in both horizontal and vertical modes, assuming they work as I expect.