### PR TITLE
Fix layout bugs when rendering weirdly sized sets

### DIFF
--- a/data/abc/rockfield.abc
+++ b/data/abc/rockfield.abc
@@ -1,0 +1,14 @@
+X: 1
+T: Rockfield
+R: reel
+M: 4/4
+L: 1/8
+K: Amin
+"Am"EAAG ~A2 cA|"G"GEEE CEGE|"F"DAAG ABce|"G"~d2 de dcAG|
+"Am"EAAG ~A2 cA|"G"GEEE CEGE|"F"DAAG ABcd|"G"efed cAAG|
+"Am"EAAG ~A2 cA|"C"GEEE CEGE|"Dm7"DAAG ABcd|"Em7"eage fede|
+"F"cAAG ~A2 cA|GEEE CEGE|"G"DAAG ~A3G|(3ABc AG ABcd||
+"Am"~e3a agea|"C"geee edce|"Dm"dAAG ~A3e|"Em"dcAG ABcd|
+"Am"~e3a agea|"C"geee edce|"Dm"d2ag ageg|"Asus2/E"~d3a aged|
+"Am"~e3a agea|"C"geee edce|"Dm"dAAG ~A3e|"Em"dcAG (3ABc AG|
+"Gsus2/D"~E3G ABcd|e2ef edce|"Asus2/E"dcAe dcAe|1 dcde dcAG:|2 dcde gedB|A8|| 

--- a/data/abc/the-rizla.abc
+++ b/data/abc/the-rizla.abc
@@ -1,0 +1,15 @@
+X: 1
+T: The Rizla
+R: reel
+C: Charlie McKerron
+M: 4/4
+L: 1/8
+K: Amin
+|:"Am"c2 cA "G"B2 BA|Beed BAAB|"Am"c2 cA "G"B2 BA|GEDE GDEG|
+"F"AB c/B/A B2 BA|Beed BAAB|"G"c/B/A BG AGEG|ED D/E/G A4:|
+|:"Dm"DEFA "Em"E2 AB|c/B/A BG AGEG|"Dm"DEFA "Em"G2 DE-|EDEA EA,A,E|
+"Dm"DEFA "Em"E2 AB|c/B/A Bc edB"F"c-|cABG ED D/E/G|1 "G"A6- AA:|2 "G"A6- AB||
+|:"Am"c2 cA "G"B2 BA|GEDE GDEG|"Am"AB c/B/A "G"B2 BA|Beed BAAB|
+"Am"c2 cA "G"B2 BA|GEDE GDEG|"F"AB c/B/A "G"B2 BA|1 Bded BAAB:|2 Bded BAGA||
+|:"Am"DEAE cEAE|"C"DEeE dEeE|"Dm"DEAB c/B/A ce|"Em"aged cAGA|
+"Fmaj7"DEAE cEAE|DEeE deAB|"Gadd2"c2 cA B2 BA|1 Beed BAGA:|2 Beed BA A2|| 

--- a/data/abc/toward-the-sun.abc
+++ b/data/abc/toward-the-sun.abc
@@ -1,0 +1,11 @@
+X: 1
+T: Toward The Sun
+C: Brian Finnegan
+R: reel
+M: 4/4
+L: 1/8
+K: Gm
+|:"Gm"G2 d2 g3 g|"Eb"b2 e2 e2 de|"Bb"f2 B2 BccB|"F"cfdB c2 BA|
+"Gm"G2 d2 g2 fg|"Eb"beed ~e2 de|"Bb"f2 B2 BccB|1 "F"cf d3 cBA:|2 "F"c z3 e4||
+|:"Gm"dGGF G2 FG|"Eb"BG E3 e3|"Bb"d ~F3 AFAB|"F"cA F2 e2 e2|
+"Gm"dGGF "Gm/F"G2 FG|"Eb"BEED E2 DE|1 "Cm"F2 B,F DF (3DCB,|"Dm"CDFG Bcde:|2 "Cm"F2 B,F c2 cB|"Dm"c2 z4 BA:|

--- a/data/folder.tex
+++ b/data/folder.tex
@@ -67,4 +67,11 @@ Probably don't use this set for dancing
 \abcinput{abc/old-morpeth-rant}
 \abcinput{abc/silver-spear}
 \abcinput{abc/paddys}
+\clearpage
+
+\subsection{Reels 2 --- More reels}
+A set of tunes where the dots are in vastly different aspect ratios
+\abcinput{abc/the-rizla}
+\abcinput{abc/rockfield}
+\abcinput{abc/toward-the-sun}
 \end{document}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
-		"test:integration": "playwright test",
+		"test:integration": "playwright test --fully-parallel",
 		"test:unit": "vitest --run",
 		"prepare": "husky"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flyingcatband/tunebook",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"license": "MIT",
 	"files": [
 		"dist"

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -554,7 +554,7 @@ test('pages remain the same after navigating away and back', async ({ page }) =>
 
 // Skip the property-based tests for now since they don't reliably work on CI,
 // but the failures are very minor and not worth fixing right now.
-describe.skip('properties', () => {
+describe('properties', () => {
 	const TEST_TIMEOUT_MILLIS = 15_000;
 	// Set the playwright test timeout larger than the fast-check timeout
 	test.setTimeout(TEST_TIMEOUT_MILLIS * 3);
@@ -629,7 +629,7 @@ describe.skip('properties', () => {
 		});
 	});
 
-	test(`zooming in from fit to page always makes a tune invisible`, async ({ page }) => {
+	test.skip(`zooming in from fit to page always makes a tune invisible`, async ({ page }) => {
 		await page.goto('/Jigs-2-Lots-of-jigs');
 		await expect(page.getByText('The Cliffs Of Moher', { exact: true })).toBeInViewport();
 		await fc.assert(
@@ -665,7 +665,7 @@ describe.skip('properties', () => {
 		);
 	});
 
-	test(`zooming in with notes hidden makes a tune invisible`, async ({ page }) => {
+	test.skip(`zooming in with notes hidden makes a tune invisible`, async ({ page }) => {
 		await page.goto('/Jigs-2-Lots-of-jigs');
 		await expect(page.getByText('The Cliffs Of Moher', { exact: true })).toBeInViewport();
 		await fc.assert(
@@ -700,7 +700,10 @@ describe.skip('properties', () => {
 			{
 				timeout: TEST_TIMEOUT_MILLIS,
 				interruptAfterTimeLimit: TEST_TIMEOUT_MILLIS,
-				examples: [[363, 971]]
+				examples: [
+					[363, 971],
+					[368, 1994]
+				]
 			}
 		);
 	});


### PR DESCRIPTION
- Ensure that manually paginated tunes always appear in order
- Ensure that tunes are fitted to page based on true rather than estimated aspect ratios